### PR TITLE
Attempt browser authentication

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,15 @@ func main() {
 		log.Fatalln(err)
 	}
 	if len(accs) == 0 {
-		log.Fatalln("google-cloud-sdk is not authentificated to any account")
+		if err := gcloud.Authenticate(); err != nil {
+			log.Fatalln(err)
+		}
+		// Now that we've authenticated, try to Re-Read the accounts again and exit if
+		// we got an error.
+		accs, err = gcloud.ReadAccounts()
+		if err != nil {
+			log.Fatalln(err)
+		}
 	}
 
 	if len(accs) > 1 {

--- a/providers/gcloud.go
+++ b/providers/gcloud.go
@@ -98,3 +98,12 @@ func (g *GCloudProvider) SelectCluster(cluster string) error {
 	zone := strings.Split(cluster, "\t")[1]
 	return exec.Command("gcloud", "container", "clusters", "get-credentials", clusterID, "--zone", zone, "--project", g.ProjectID).Run()
 }
+
+// Authenticate attempts to initiate authentication by means of the `gcloud auth login --launch-browser` command.
+func (g *GCloudProvider) Authenticate() error {
+	_, err := exec.Command("gcloud", "auth", "login", "--launch-browser").Output()
+	if err != nil {
+		return errors.Wrap(err, "Failed to initiate authentication")
+	}
+	return err
+}


### PR DESCRIPTION
Prior we would just fatal out of the application. This will
attempt to perform a browser login to associate a particular account to
the current configuration and then perform a retry on the ReadAccounts
function (and then fatal if none or error was found)